### PR TITLE
Adding transliteration/romanization for non-alphabet characters

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -462,6 +462,7 @@ function addElementEnv() {
   tooltipContainer = $("<div/>", {
     id: "mttContainer",
     class: "bootstrapiso notranslate", //use bootstrapiso class to apply bootstrap isolation css, prevent google web translate
+    'data-html': "true"
   }).appendTo(document.body);
 
   tooltipContainer.tooltip({

--- a/src/translator/bing.js
+++ b/src/translator/bing.js
@@ -111,7 +111,7 @@ export default class google extends BaseTranslator {
       var transliteration = ''
       if(ENABLED_TRANSLITERATION.includes(fromLang) && res[1]){
         // console.log(res[1]['inputTransliteration'])
-        transliteration = `<br><br> <h2>${res[1]['inputTransliteration']}</h2>`
+        transliteration = `<br><br> <h5>${res[1]['inputTransliteration']}</h5>`
       }
       var detectedLang = res[0]["detectedLanguage"]["language"];
       var translatedText = `${res[0]["translations"][0]["text"]}${transliteration}`;

--- a/src/translator/bing.js
+++ b/src/translator/bing.js
@@ -110,7 +110,6 @@ export default class google extends BaseTranslator {
     if (res && res[0]) {
       var transliteration = ''
       if(ENABLED_TRANSLITERATION.includes(fromLang) && res[1]){
-        // console.log(res[1]['inputTransliteration'])
         transliteration = `<br><br> <h5>${res[1]['inputTransliteration']}</h5>`
       }
       var detectedLang = res[0]["detectedLanguage"]["language"];

--- a/src/translator/bing.js
+++ b/src/translator/bing.js
@@ -78,6 +78,8 @@ var bingLangCode = {
   "zh-TW": "zh-Hant",
 };
 
+const ENABLED_TRANSLITERATION = ['ja']
+
 export default class google extends BaseTranslator {
   static langCodeJson = bingLangCode;
 
@@ -106,8 +108,13 @@ export default class google extends BaseTranslator {
   }
   static wrapResponse(res, fromLang, targetLang) {
     if (res && res[0]) {
+      var transliteration = ''
+      if(ENABLED_TRANSLITERATION.includes(fromLang) && res[1]){
+        // console.log(res[1]['inputTransliteration'])
+        transliteration = `<br><br> <h2>${res[1]['inputTransliteration']}</h2>`
+      }
       var detectedLang = res[0]["detectedLanguage"]["language"];
-      var translatedText = res[0]["translations"][0]["text"];
+      var translatedText = `${res[0]["translations"][0]["text"]}${transliteration}`;
       return { translatedText, detectedLang };
     }
   }


### PR DESCRIPTION
Hi!, I found this tool is helpful for me, since I'm also learning Japanese I'd really need to have romanization/transliteration for Japanese characters, hence I added this feature, for now, I can only make it work with **Bing**, (google translate doesn't have this result on their response) and I only add `ja` language code, I guess we can add another language like `chinese`, `arabic`, `cyrillic` and some other country who's not using alphabet. 

I'll add toggle to enable this feature & probably more specific feature that I need later, this just proof of concept & I hope you & the other find this useful as well. 🙏🏼 

Here's the screenshot 
<img width="333" alt="Screenshot 2023-08-13 at 17 41 48" src="https://github.com/ttop32/MouseTooltipTranslator/assets/17568508/7414d2b2-9fe4-4669-8d68-790b9f8c05d3">
