### PR TITLE
add quick shortcut annotation

### DIFF
--- a/public/pdfjs/web/viewer.js
+++ b/public/pdfjs/web/viewer.js
@@ -2389,6 +2389,12 @@ function webViewerKeyDown(evt) {
       case 115:
         PDFViewerApplication.pdfSidebar?.toggle();
         break;
+      case 84:
+        document.getElementById("editorFreeText")?.click();
+        break;
+      case 68:
+        document.getElementById("editorInk")?.click();
+        break;
     }
     if (turnPage !== 0 && (!turnOnlyIfPageFit || pdfViewer.currentScaleValue === "page-fit")) {
       if (turnPage > 0) {


### PR DESCRIPTION
When learning languages, I want to note in pdf quickly. I think it is necessary to provide quick shortcuts for note, `t` for "text", `d` for "draw" 