### PR TITLE
Makes free text, ink shortcut not activate when a function key is pressed

### DIFF
--- a/src/pdf/pdfInject.js
+++ b/src/pdf/pdfInject.js
@@ -134,7 +134,7 @@ function addCustomKeystroke() {
     if (util.getFocusedWritingBox()) {
       return;
     }
-    if (evt.altKey || evt.ctrlKey) {
+    if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shiftKey) {
       return;
     }
     switch (evt.code) {

--- a/src/pdf/pdfInject.js
+++ b/src/pdf/pdfInject.js
@@ -1,6 +1,5 @@
 import delay from "delay";
 import $ from "jquery";
-import ky from "ky";
 
 import * as util from "/src/util";
 
@@ -135,7 +134,9 @@ function addCustomKeystroke() {
     if (util.getFocusedWritingBox()) {
       return;
     }
-
+    if (evt.altKey || evt.ctrlKey) {
+      return;
+    }
     switch (evt.code) {
       case "KeyT":
         document.getElementById("editorFreeText")?.click();


### PR DESCRIPTION
Allows users to create new tabs with the "Ctrl + T" shortcut and come back to their PDFs without having to exit free text mode every time manually. Similarly for "Ctrl + D".