### PR TITLE
Fire extension onMouseMove instead of on interval

### DIFF
--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -9,6 +9,7 @@ import * as util from "/src/util";
 var clientX = 0;
 var clientY = 0;
 var lastRunMouseover = new Date();
+var hasQueuedMouseover = false;
 var _win;
 var _isIframe = false;
 var styleElement;
@@ -19,6 +20,7 @@ export function enableMouseoverTextEvent(
   textDetectTime = 0.7
 ) {
   _win = _window;
+  textDetectTime = Number(textDetectTime) * 1000;
 
   window.addEventListener("mousemove", async (e) => {
     //if is ebook viewer event, take ebook window
@@ -35,9 +37,19 @@ export function enableMouseoverTextEvent(
     clientX = e.clientX;
     clientY = e.clientY;
 
-    if (new Date() - lastRunMouseover > textDetectTime) {
-      lastRunMouseover = new Date();
-      triggerMouseoverText(await getMouseoverText(clientX, clientY));
+    if (hasQueuedMouseover == false) {
+      if (new Date() - lastRunMouseover > textDetectTime) {
+        lastRunMouseover = new Date();
+        triggerMouseoverText(await getMouseoverText(clientX, clientY));
+      }
+      else {
+        hasQueuedMouseover = true;
+        setTimeout(async() => {
+          hasQueuedMouseover = false;
+          lastRunMouseover = new Date();
+          triggerMouseoverText(await getMouseoverText(clientX, clientY));
+        }, textDetectTime);
+      }
     }
   });
 }

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -9,8 +9,6 @@ import {debounce} from "lodash";
 
 var clientX = 0;
 var clientY = 0;
-var lastRunMouseover = new Date();
-var hasQueuedMouseover = false;
 var _win;
 var _isIframe = false;
 var styleElement;
@@ -89,7 +87,6 @@ async function getTextFromRange(range) {
       //check mouse xy overlap the range element
       if (checkXYInElement(rangeClone, clientX, clientY)) {
         output[detectType] = extractTextFromRange(rangeClone);
-if (detectType == "sentence") { console.log(output[detectType])};
         output[detectType + "_range"] = rangeClone;
       }
     } catch (error) {

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -5,6 +5,7 @@
 // 4. range to text
 
 import * as util from "/src/util";
+import {debounce} from "lodash";
 
 var clientX = 0;
 var clientY = 0;
@@ -21,6 +22,9 @@ export function enableMouseoverTextEvent(
 ) {
   _win = _window;
   textDetectTime = Number(textDetectTime) * 1000;
+  const triggerMouseoverTextWithDelay = debounce(async() => {
+    triggerMouseoverText(await getMouseoverText(clientX, clientY));
+  }, textDetectTime);
 
   window.addEventListener("mousemove", async (e) => {
     //if is ebook viewer event, take ebook window
@@ -37,20 +41,7 @@ export function enableMouseoverTextEvent(
     clientX = e.clientX;
     clientY = e.clientY;
 
-    if (hasQueuedMouseover == false) {
-      if (new Date() - lastRunMouseover > textDetectTime) {
-        lastRunMouseover = new Date();
-        triggerMouseoverText(await getMouseoverText(clientX, clientY));
-      }
-      else {
-        hasQueuedMouseover = true;
-        setTimeout(async() => {
-          hasQueuedMouseover = false;
-          lastRunMouseover = new Date();
-          triggerMouseoverText(await getMouseoverText(clientX, clientY));
-        }, textDetectTime);
-      }
-    }
+    triggerMouseoverTextWithDelay();
   });
 }
 
@@ -98,6 +89,7 @@ async function getTextFromRange(range) {
       //check mouse xy overlap the range element
       if (checkXYInElement(rangeClone, clientX, clientY)) {
         output[detectType] = extractTextFromRange(rangeClone);
+if (detectType == "sentence") { console.log(output[detectType])};
         output[detectType + "_range"] = rangeClone;
       }
     } catch (error) {

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -16,7 +16,7 @@ const PARENT_TAGS_TO_EXCLUDE = ["STYLE", "SCRIPT", "TITLE"];
 
 export function enableMouseoverTextEvent(
   _window = window,
-  textDetectTime = 0.7
+  textDetectTime = 0.1
 ) {
   _win = _window;
   textDetectTime = Number(textDetectTime) * 1000;

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -8,6 +8,7 @@ import * as util from "/src/util";
 
 var clientX = 0;
 var clientY = 0;
+var lastRunMouseover = new Date();
 var _win;
 var _isIframe = false;
 var styleElement;
@@ -18,13 +19,8 @@ export function enableMouseoverTextEvent(
   textDetectTime = 0.7
 ) {
   _win = _window;
-  textDetectTime = Number(textDetectTime) * 1000;
 
-  setInterval(async () => {
-    triggerMouseoverText(await getMouseoverText(clientX, clientY));
-  }, textDetectTime);
-
-  window.addEventListener("mousemove", (e) => {
+  window.addEventListener("mousemove", async (e) => {
     //if is ebook viewer event, take ebook window
     if (e.ebookWindow) {
       _win = e.ebookWindow;
@@ -38,6 +34,11 @@ export function enableMouseoverTextEvent(
     //else record mouse xy
     clientX = e.clientX;
     clientY = e.clientY;
+
+    if (new Date() - lastRunMouseover > textDetectTime) {
+      lastRunMouseover = new Date();
+      triggerMouseoverText(await getMouseoverText(clientX, clientY));
+    }
   });
 }
 
@@ -66,6 +67,7 @@ async function getMouseoverText(x, y) {
   //get text from range
   var mouseoverText = await getTextFromRange(range);
   textElement?.remove();
+
   return mouseoverText;
 }
 async function getTextFromRange(range) {

--- a/src/event/selection.js
+++ b/src/event/selection.js
@@ -2,7 +2,7 @@
  * Selection related functions
  */
 import $ from "jquery";
-import { debounce, throttle } from "lodash";
+import { debounce } from "lodash";
 import * as util from "/src/util";
 
 var _win;

--- a/src/event/selection.js
+++ b/src/event/selection.js
@@ -9,7 +9,7 @@ var _win;
 var prevNoneSelect = false;
 export function enableSelectionEndEvent(
   _window = window,
-  textDetectTime = 0.7
+  textDetectTime = 0.1
 ) {
   _win = _window;
   textDetectTime = Number(textDetectTime) * 1000;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -182,7 +182,7 @@ var voiceRateList = util.getRangeOption(0.5, 2.1, 0.1, 1);
 var voiceRepeatList = util.getRangeOption(1, 11);
 var tooltipBackgroundBlurList = util.getRangeOption(0, 21);
 var distanceList = util.getRangeOption(0, 41);
-var tooltipIntervalTimeList = util.getRangeOption(0.5, 2.1, 0.1, 1);
+var tooltipIntervalTimeList = util.getRangeOption(0.1, 2.1, 0.1, 1);
 
 var tooltipPositionList = {
   Follow: "follow",

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -89,7 +89,7 @@ export var defaultData = {
   ignoreCallbackOptionList: ["historyList"],
   popupCount: "0",
   langPriority: { auto: 9999999, null: 9999999 },
-  tooltipIntervalTime: "0.7",
+  tooltipIntervalTime: "0.1",
 
   cardPlayMeta: ["image"],
   cardTagSelected: [],


### PR DESCRIPTION
Currently, the extension is relying on setInterval to determine when to fire. This can cause the function to fire an excessive amount of times even when the page is idle, contributing to CPU usage. The problem is worse when more tabs are opened.

Instead, it's better to fire immediately on mouse move, with a delay if the function had recently been fired.
Doing this also allows the default time delay to be reduced.