### PR TITLE
Add secondary target language with configurable hotkey

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -17,6 +17,9 @@
 	"Translate_Into": {
 		"message": "Translate Into"
 	},
+	"Translate_Into_2": {
+		"message": "Secondary Translate Into"
+	},
 	"Translator_Engine": {
 		"message": "Translator Engine"
 	},
@@ -64,6 +67,9 @@
 	},
 	"Toggle_Mouseover_Text_Type_When": {
 		"message": "Toggle Mouseover Text Type When"
+	},
+	"Secondary_Language_When": {
+		"message": "Secondary Language When"
 	},
 	"GRAPHIC______________________________________": {
 		"message": "GRAPHIC                                      "

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -138,9 +138,13 @@ async function stageTooltipText(text, actionType, range) {
     keyDownList[setting["TTSWhen"]] ||
     (setting["TTSWhen"] == "select" && actionType == "select");
   var isTtsSwap = keyDownDoublePress[setting["TTSWhen"]];
-  var isTooltipOn = keyDownList[setting["showTooltipWhen"]];
+  var useSecondary =
+    setting["keySecondaryLang"] != "null" &&
+    keyDownList[setting["keySecondaryLang"]] &&
+    setting["translateTarget2"] != "null";
+  var isTooltipOn = keyDownList[setting["showTooltipWhen"]] || useSecondary;
   var timestamp = Number(Date.now());
-  
+
   // skip if mouse target is tooltip or no text, if no new word or  tab is not activated
   // hide tooltip, if  no text
   // if tooltip is off, hide tooltip
@@ -169,7 +173,7 @@ async function stageTooltipText(text, actionType, range) {
   var translatedData = await util.requestTranslate(
     text,
     setting["translateSource"],
-    setting["translateTarget"],
+    useSecondary ? setting["translateTarget2"] : setting["translateTarget"],
     setting["translateReverseTarget"]
   );
   var { targetText, sourceLang, targetLang } = translatedData;
@@ -652,7 +656,12 @@ async function runKeydownPostProcess(key, detectKeyDown) {
       setting["mouseoverTextType"] = setting["mouseoverTextType"] == "word" ? "sentence" : "word";
       setting.save();
     }
-    restartWordProcess();
+    if (setting["keySecondaryLang"]==key && setting["translateTarget2"] != "null") {
+      stagedText = null;
+      stageTooltipTextHover(null, false);
+    } else {
+      restartWordProcess();
+    }
   }
 
   if (util.isCharKey(key)) {
@@ -766,6 +775,10 @@ async function releaseKeydownList(key) {
   keyDownList[key] = false;
   if (key == setting["keySpeechRecognition"]) {
     speech.stopSpeechRecognition();
+  }
+  if (key == setting["keySecondaryLang"] && setting["translateTarget2"] != "null") {
+    stagedText = null;
+    stageTooltipTextHover(null, false);
   }
 }
 

--- a/src/util/setting_default.js
+++ b/src/util/setting_default.js
@@ -144,6 +144,12 @@ export var settingDict = {
     optionList: langList,
     settingTab: "main",
   },
+  translateTarget2: {
+    default: "null",
+    i18nKey: "Translate_Into_2",
+    optionList: langListWithNone,
+    settingTab: "main",
+  },
   translatorVendor: {
     default: "google",
     i18nKey: "Translator_Engine",
@@ -227,6 +233,12 @@ export var settingDict = {
   keyToggleMouseoverTextType: {
     default: "F8",
     i18nKey: "Toggle_Mouseover_Text_Type_When",
+    optionList: keyList,
+    settingTab: "keyboard",
+  },
+  keySecondaryLang: {
+    default: "null",
+    i18nKey: "Secondary_Language_When",
     optionList: keyList,
     settingTab: "keyboard",
   },


### PR DESCRIPTION
## Summary
- Adds a **"Secondary Translate Into"** setting (Main tab) — a second target language alongside the primary one
- Adds a **"Secondary Language When"** hotkey setting (Keyboard tab) — while this key is held, the tooltip translates into the secondary language; releasing reverts to the primary
- No toggle state — hold to switch, release to revert

## Use case
Useful when reading text in a foreign language and wanting quick access to two different translations — e.g. primary → English for comprehension, hold a key → Russian for a native-speaker check, without visiting settings.

## How it works
- Two new entries in `setting_default.js` (auto-generates the UI via the existing data-driven options page)
- `contentScript.js`: `useSecondary` flag computed at tooltip-display time from `keyDownList`; holding the hotkey also counts as `isTooltipOn` so no second key is required
- English i18n strings added; other locales pending Crowdin

## Test plan
- [ ] Set "Secondary Translate Into" to any language in the Main tab
- [ ] Set "Secondary Language When" to a hotkey in the Keyboard tab
- [ ] Hover over text → tooltip shows primary language
- [ ] Hold the hotkey while hovering → tooltip switches to secondary language
- [ ] Release the hotkey → tooltip reverts to primary language