### PR TITLE
feat: Add Secondary Mouseover Text Type setting

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -26,6 +26,9 @@
 	"Mouseover_Text_Type": {
 		"message": "Mouseover Text Type"
 	},
+	"Mouseover_Text_Type_2": {
+		"message": "Secondary Mouseover Text Type"
+	},
 	"Writing_Language": {
 		"message": "Writing Language"
 	},

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -18,13 +18,16 @@
 		"message": "翻译成"
 	},
 	"Translate_Into_2": {
-		"message": "Secondary Translate Into"
+		"message": "次要翻译成"
 	},
 	"Translator_Engine": {
 		"message": "翻译引擎"
 	},
 	"Mouseover_Text_Type": {
 		"message": "鼠标悬停文本类型"
+	},
+	"Mouseover_Text_Type_2": {
+		"message": "次要鼠标悬停文本类型"
 	},
 	"Writing_Language": {
 		"message": "写作语言"
@@ -69,7 +72,7 @@
 		"message": "Toggle Mouseover Text Type When"
 	},
 	"Secondary_Language_When": {
-		"message": "Secondary Language When"
+		"message": "次要语言显示"
 	},
 	"GRAPHIC______________________________________": {
 		"message": "图形                                      "

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -92,7 +92,7 @@ var listenText = "";
 
 //determineTooltipShowHide based on hover, check mouse over word on every 700ms
 function startMouseoverDetector() {
-  enableMouseoverTextEvent(window, setting, keyDownList);
+  enableMouseoverTextEvent(window, setting, () => keyDownList);
   addEventHandler("mouseoverText", stageTooltipTextHover);
 }
 

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -15,14 +15,14 @@ var _isIframe = false;
 var styleElement;
 const PARENT_TAGS_TO_EXCLUDE = ["STYLE", "SCRIPT", "TITLE"];
 var setting = {};
-var keyDownList = {};
+var getKeyDownList = {};
 var mouseTarget = null;
 const nodeLengthCache = new WeakMap();
 var prevWordSegIndex = 0;
 
-export function enableMouseoverTextEvent(_window = window, currentSetting, keyDownListParam) {
+export function enableMouseoverTextEvent(_window = window, currentSetting, keyDownListGetter) {
   setting = currentSetting;
-  keyDownList = keyDownListParam;
+  getKeyDownList = keyDownListGetter;
   var textDetectTime = setting?.["mouseoverEventInterval"] || 300;
   
   _win = _window;
@@ -45,9 +45,14 @@ export async function forceTriggerMouseoverText() {
 }
 
 function getMouseoverType() {
+  var useSecondary =
+    setting["keySecondaryLang"] != "null" &&
+    getKeyDownList()[setting["keySecondaryLang"]] &&
+    setting["translateTarget2"] != "null";
+
   //if swap key pressed, swap detect type
   //if mouse target is special web block, handle as block
-  var detectType = setting["mouseoverTextType"];
+  var detectType = useSecondary ? setting["mouseoverTextType2"] : setting["mouseoverTextType"];
   // detectType = keyDownList[setting["keyToggleMouseoverTextType"]]
   //   ? detectType == "word"
   //     ? "sentence"

--- a/src/util/setting_default.js
+++ b/src/util/setting_default.js
@@ -168,6 +168,12 @@ export var settingDict = {
     optionList: detectTypeList,
     settingTab: "main",
   },
+  mouseoverTextType2: {
+    default: "sentence",
+    i18nKey: "Mouseover_Text_Type_2",
+    optionList: detectTypeList,
+    settingTab: "main",
+  },
   writingLanguage: {
     default: "en",
     i18nKey: "Writing_Language",
@@ -394,7 +400,7 @@ export var settingDict = {
     onClick: () => {},
     onClickFuncName: "includeWhitelistCurrentWebsiteOnclickFunc",
   },
-  
+
   // advanced
 
   detectPDF: {
@@ -531,7 +537,7 @@ export var settingDict = {
     menu: false,
     settingTab: "speech",
   },
-  
+
 
   // remains
   subtitleButtonToggle: {


### PR DESCRIPTION
Allow selecting a different Mouseover Text Type for "Secondary Translate Into".
Compared to toggling the Mouseover Text Type first and then translating, the new shortcut only requires a single action.