### PR TITLE
fix: add missing Secondary_Language_When label in keyboard settings

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -71,6 +71,9 @@
 	"Mouseover_Text_Type_Key_Hold": {
 		"message": "Mouseover Text Type Key Hold"
 	},
+	"Secondary_Language_When": {
+		"message": "Secondary Language When"
+	},
 	"GRAPHIC______________________________________": {
 		"message": "GRAPHIC                                      "
 	},

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -191,6 +191,9 @@
 	"Fallback_Translator_Engine": {
 		"message": "Fallback Translator Engine"
 	},
+	"Mouseover_Text_Type_2": {
+		"message": "Secondary Mouseover Text Type"
+	},
 	"SPEECH": {
 		"message": "SPEECH"
 	},


### PR DESCRIPTION
## Summary

- The `keySecondaryLang` setting in `setting_default.js` references `i18nKey: "Secondary_Language_When"`, but this key was missing from all locale files
- As a result, the label above the **Secondary Language When** shortcut dropdown in the Keyboard settings panel rendered blank
- Added `"Secondary_Language_When"` to `public/_locales/en/messages.json` — the WebExtensions i18n spec automatically falls back to the default locale (`en`) for any locale that does not override a key, so no other locale files need changes

Also fixed a second identical bug found in the same pass:
- `mouseoverTextType2` in the **Advanced** tab referenced `i18nKey: "Mouseover_Text_Type_2"` which was also missing, causing the label above the Word/Sentence/Container dropdown to render blank
- Added `"Mouseover_Text_Type_2": { "message": "Secondary Mouseover Text Type" }`

## Test plan

- [ ] Open extension settings → **Keyboard** tab
- [ ] Confirm the Secondary Language shortcut dropdown now shows the label **"Secondary Language When"** above it
- [ ] Open extension settings → **Advanced** tab
- [ ] Confirm the Word/Sentence/Container dropdown now shows the label **"Secondary Mouseover Text Type"** above it
- [ ] Confirm all other setting labels are unaffected