### PR TITLE
feat: add BookFusion.com EPUB reader support

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1133,7 +1133,22 @@ function bindBookFusionIframe() {
     for (const iframe of iframes) {
       if (bound.has(iframe) || !iframe.contentWindow) continue;
       bound.add(iframe);
-      iframe.contentWindow.addEventListener("mousemove", (e) => {
+      const win = iframe.contentWindow;
+      const dispatchSelect = (text) => {
+        const evt = new CustomEvent("selectionEnd", { bubbles: true, cancelable: false });
+        evt.selectedText = text;
+        document.dispatchEvent(evt);
+      };
+      let selectTimer;
+      win.document.addEventListener("selectionchange", () => {
+        clearTimeout(selectTimer);
+        selectTimer = setTimeout(() => dispatchSelect(win.getSelection()?.toString() || ""), 700);
+      }, false);
+      win.document.addEventListener("mouseup", () => {
+        clearTimeout(selectTimer);
+        dispatchSelect(win.getSelection()?.toString() || "");
+      }, false);
+      win.document.addEventListener("mousemove", (e) => {
         bookFusionActiveIframe = iframe;
         const clRect = iframe.getBoundingClientRect();
         const scaleX = clRect.width / (iframe.offsetWidth || 1);
@@ -1148,7 +1163,7 @@ function bindBookFusionIframe() {
         document.dispatchEvent(evt);
       });
       ["keydown", "keyup"].forEach((eventName) => {
-        iframe.contentWindow.addEventListener(eventName, (e) => {
+        win.addEventListener(eventName, (e) => {
           const evt = new CustomEvent(eventName, { bubbles: true, cancelable: false });
           evt.key = e?.key;
           evt.code = e?.code;

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -689,10 +689,12 @@ async function startAutoReader() {
   util.clearSelection();
   util.requestKillAutoReaderTabs();
   await killAutoReader();
-  var { mouseoverText, mouseoverRange } = await getMouseoverText(
-    clientX,
-    clientY
-  );
+  // hoveredData.mouseoverRange was detected with correct iframe-local coords;
+  // re-detecting via clientX/clientY fails for scaled iframes (BookFusion)
+  // because those are outer-page coords, not iframe-local coords.
+  var mouseoverRange =
+    hoveredData?.mouseoverRange ||
+    (await getMouseoverText(clientX, clientY)).mouseoverRange;
   processAutoReader(mouseoverRange, isTtsSwap);
 }
 

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -61,6 +61,7 @@ var isStopAutoReaderOn = false;
 var tooltipRemoveTimeoutId = "";
 var tooltipRemoveTime = 3000;
 var autoReaderScrollTime = 400;
+var bookFusionActiveIframe = null;
 
 var listenText = "";
 
@@ -428,15 +429,12 @@ function highlightText(range, force = false) {
     var ebookViewerRect = util.getEbookIframe()?.getBoundingClientRect();
     adjustX += ebookViewerRect?.left;
     adjustY += ebookViewerRect?.top;
-  } else if (util.isBookFusion()) {
-    var bfIframe = util.getEbookIframe();
-    if (bfIframe) {
-      var bfRect = bfIframe.getBoundingClientRect();
-      scaleX = bfRect.width / (bfIframe.offsetWidth || 1);
-      scaleY = bfRect.height / (bfIframe.offsetHeight || 1);
-      adjustX += bfRect.left;
-      adjustY += bfRect.top;
-    }
+  } else if (util.isBookFusion() && bookFusionActiveIframe) {
+    var bfRect = bookFusionActiveIframe.getBoundingClientRect();
+    scaleX = bfRect.width / (bookFusionActiveIframe.offsetWidth || 1);
+    scaleY = bfRect.height / (bookFusionActiveIframe.offsetHeight || 1);
+    adjustX += bfRect.left;
+    adjustY += bfRect.top;
   }
 
   for (var rect of rects) {
@@ -755,6 +753,13 @@ async function preloadNextTranslation(stagedRange) {
 
 function scrollAutoReader(range) {
   var rect = range.getBoundingClientRect();
+  if (util.isBookFusion() && bookFusionActiveIframe) {
+    const iframeRect = bookFusionActiveIframe.getBoundingClientRect();
+    const bfScaleY = iframeRect.height / (bookFusionActiveIframe.offsetHeight || 1);
+    const bfScrollTop = window.scrollY + iframeRect.top + rect.top * bfScaleY - window.innerHeight / 2;
+    $("body,html").animate({ scrollTop: bfScrollTop }, autoReaderScrollTime);
+    return;
+  }
   const scrollContainer = util.isPDFViewer()
     ? $("#viewerContainer")
     : $("body,html");
@@ -1126,34 +1131,37 @@ function injectGoogleDocAnnotation() {
 //bookfusion=========================================================
 function bindBookFusionIframe() {
   if (!util.isBookFusion()) return;
-  let boundSrc = "";
+  const bound = new WeakSet();
   setInterval(() => {
-    const iframe = document.querySelector('iframe[id^="bf-epub-view-"]');
-    if (!iframe || iframe.src === boundSrc) return;
-    boundSrc = iframe.src;
-    iframe.contentWindow.addEventListener("mousemove", (e) => {
-      const clRect = iframe.getBoundingClientRect();
-      const scaleX = clRect.width / (iframe.offsetWidth || 1);
-      const scaleY = clRect.height / (iframe.offsetHeight || 1);
-      const evt = new CustomEvent("mousemove", { bubbles: true, cancelable: false });
-      evt.ebookWindow = iframe.contentWindow;
-      evt.clientX = e.clientX * scaleX + clRect.left;
-      evt.clientY = e.clientY * scaleY + clRect.top;
-      evt.iframeX = e.clientX;
-      evt.iframeY = e.clientY;
-      window.dispatchEvent(evt);
-      document.dispatchEvent(evt);
-    });
-    ["keydown", "keyup"].forEach((eventName) => {
-      iframe.contentWindow.addEventListener(eventName, (e) => {
-        const evt = new CustomEvent(eventName, { bubbles: true, cancelable: false });
-        evt.key = e?.key;
-        evt.code = e?.code;
-        evt.ctrlKey = e?.ctrlKey;
+    const iframes = document.querySelectorAll('iframe[id^="bf-epub-view-"]');
+    for (const iframe of iframes) {
+      if (bound.has(iframe) || !iframe.contentWindow) continue;
+      bound.add(iframe);
+      iframe.contentWindow.addEventListener("mousemove", (e) => {
+        bookFusionActiveIframe = iframe;
+        const clRect = iframe.getBoundingClientRect();
+        const scaleX = clRect.width / (iframe.offsetWidth || 1);
+        const scaleY = clRect.height / (iframe.offsetHeight || 1);
+        const evt = new CustomEvent("mousemove", { bubbles: true, cancelable: false });
+        evt.ebookWindow = iframe.contentWindow;
+        evt.clientX = e.clientX * scaleX + clRect.left;
+        evt.clientY = e.clientY * scaleY + clRect.top;
+        evt.iframeX = e.clientX;
+        evt.iframeY = e.clientY;
         window.dispatchEvent(evt);
         document.dispatchEvent(evt);
       });
-    });
+      ["keydown", "keyup"].forEach((eventName) => {
+        iframe.contentWindow.addEventListener(eventName, (e) => {
+          const evt = new CustomEvent(eventName, { bubbles: true, cancelable: false });
+          evt.key = e?.key;
+          evt.code = e?.code;
+          evt.ctrlKey = e?.ctrlKey;
+          window.dispatchEvent(evt);
+          document.dispatchEvent(evt);
+        });
+      });
+    }
   }, 1000);
 }
 

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -69,6 +69,7 @@ var listenText = "";
 (async function initMouseTooltipTranslator() {
   try {
     injectGoogleDocAnnotation(); //check google doc and add annotation env var
+    bindBookFusionIframe(); // bridge bookfusion iframe events
     loadDestructor(); //remove previous tooltip script
     await getSetting(); //load setting
     if (checkExcludeUrl()) {
@@ -422,10 +423,20 @@ function highlightText(range, force = false) {
   rects = util.filterOverlappedRect(rects);
   var adjustX = window.scrollX;
   var adjustY = window.scrollY;
+  var scaleX = 1, scaleY = 1;
   if (util.isEbookReader()) {
     var ebookViewerRect = util.getEbookIframe()?.getBoundingClientRect();
     adjustX += ebookViewerRect?.left;
     adjustY += ebookViewerRect?.top;
+  } else if (util.isBookFusion()) {
+    var bfIframe = util.getEbookIframe();
+    if (bfIframe) {
+      var bfRect = bfIframe.getBoundingClientRect();
+      scaleX = bfRect.width / (bfIframe.offsetWidth || 1);
+      scaleY = bfRect.height / (bfIframe.offsetHeight || 1);
+      adjustX += bfRect.left;
+      adjustY += bfRect.top;
+    }
   }
 
   for (var rect of rects) {
@@ -433,10 +444,10 @@ function highlightText(range, force = false) {
       class: "mtt-highlight",
       css: {
         position: "absolute",
-        left: rect.left + adjustX,
-        top: rect.top + adjustY,
-        width: rect.width,
-        height: rect.height,
+        left: rect.left * scaleX + adjustX,
+        top: rect.top * scaleY + adjustY,
+        width: rect.width * scaleX,
+        height: rect.height * scaleY,
       },
     }).appendTo("body");
   }
@@ -1110,6 +1121,40 @@ function injectGoogleDocAnnotation() {
   var s = document.createElement("script");
   s.src = browser.runtime.getURL("googleDocInject.js"); //chrome.runtime.getURL("js/docs-canvas.js");
   document.documentElement.appendChild(s);
+}
+
+//bookfusion=========================================================
+function bindBookFusionIframe() {
+  if (!util.isBookFusion()) return;
+  let boundSrc = "";
+  setInterval(() => {
+    const iframe = document.querySelector('iframe[id^="bf-epub-view-"]');
+    if (!iframe || iframe.src === boundSrc) return;
+    boundSrc = iframe.src;
+    iframe.contentWindow.addEventListener("mousemove", (e) => {
+      const clRect = iframe.getBoundingClientRect();
+      const scaleX = clRect.width / (iframe.offsetWidth || 1);
+      const scaleY = clRect.height / (iframe.offsetHeight || 1);
+      const evt = new CustomEvent("mousemove", { bubbles: true, cancelable: false });
+      evt.ebookWindow = iframe.contentWindow;
+      evt.clientX = e.clientX * scaleX + clRect.left;
+      evt.clientY = e.clientY * scaleY + clRect.top;
+      evt.iframeX = e.clientX;
+      evt.iframeY = e.clientY;
+      window.dispatchEvent(evt);
+      document.dispatchEvent(evt);
+    });
+    ["keydown", "keyup"].forEach((eventName) => {
+      iframe.contentWindow.addEventListener(eventName, (e) => {
+        const evt = new CustomEvent(eventName, { bubbles: true, cancelable: false });
+        evt.key = e?.key;
+        evt.code = e?.code;
+        evt.ctrlKey = e?.ctrlKey;
+        window.dispatchEvent(evt);
+        document.dispatchEvent(evt);
+      });
+    });
+  }, 1000);
 }
 
 // youtube================================

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -755,13 +755,7 @@ async function preloadNextTranslation(stagedRange) {
 
 function scrollAutoReader(range) {
   var rect = range.getBoundingClientRect();
-  if (util.isBookFusion() && bookFusionActiveIframe) {
-    const iframeRect = bookFusionActiveIframe.getBoundingClientRect();
-    const bfScaleY = iframeRect.height / (bookFusionActiveIframe.offsetHeight || 1);
-    const bfScrollTop = window.scrollY + iframeRect.top + rect.top * bfScaleY - window.innerHeight / 2;
-    $("body,html").animate({ scrollTop: bfScrollTop }, autoReaderScrollTime);
-    return;
-  }
+  if (util.isBookFusion()) return;
   const scrollContainer = util.isPDFViewer()
     ? $("#viewerContainer")
     : $("body,html");

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -232,7 +232,12 @@ export function isPDF() {
 export function getEbookIframe() {
   var shadows = getAllShadows();
   var iframe = shadows?.[1]?.querySelectorAll("iframe")[0];
-  return iframe;
+  if (iframe) return iframe;
+  return document.querySelector('iframe[id^="bf-epub-view-"]') ?? null;
+}
+
+export function isBookFusion() {
+  return window.location.hostname === "reader.bookfusion.com";
 }
 
 export function getPDFUrl(url){


### PR DESCRIPTION
## Summary
- Bridges `mousemove` and `keydown`/`keyup` events from BookFusion's blob iframe (`iframe[id^="bf-epub-view-"]`) to the outer page, matching the same pattern used for Google Play Books / foliate reader
- Compensates for BookFusion's `transform: scale(1.3)` on the iframe — mouse coordinates are scaled before dispatch so tooltip positioning is accurate
- Text detection uses raw iframe-local coordinates via `evt.ebookWindow` / `evt.iframeX/Y` (unchanged mechanism)
- Highlight rect overlay is also scale-corrected for BookFusion
- Adds `isBookFusion()` utility to `src/util/index.js`

## Test plan
- [ ] Open a book on reader.bookfusion.com
- [ ] Hover over a single word — translation tooltip should appear
- [ ] Confirm tooltip position matches the hovered word (scale compensation working)
- [ ] Enable "Mouseover Highlight Text" — confirm highlight rect aligns with the word
- [ ] Confirm keyboard shortcuts (hold key for tooltip) work inside the reader