### PR TITLE
fix: BookFusion auto-reader scroll tracking and cross-chapter continuation

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -17,6 +17,7 @@ import {
 import {
   enableMouseoverTextEvent,
   getNextExpandedRange,
+  getFirstExpandedRangeInDoc,
   getMouseoverText,
   forceTriggerMouseoverText
 } from "/src/event/mouseover";
@@ -700,6 +701,16 @@ async function startAutoReader() {
   processAutoReader(mouseoverRange, isTtsSwap);
 }
 
+function syncBookFusionActiveIframe(range) {
+  if (!util.isBookFusion() || !range) return;
+  for (const iframe of document.querySelectorAll('iframe[id^="bf-epub-view-"]')) {
+    if (iframe.contentDocument?.contains(range.startContainer)) {
+      bookFusionActiveIframe = iframe;
+      return;
+    }
+  }
+}
+
 async function processAutoReader(stagedRange, isTtsSwap) {
   if (!stagedRange || isStopAutoReaderOn) {
     hideTooltip();
@@ -707,6 +718,7 @@ async function processAutoReader(stagedRange, isTtsSwap) {
     isAutoReaderRunning = false;
     return;
   }
+  syncBookFusionActiveIframe(stagedRange);
   isAutoReaderRunning = true;
   var text = util.extractTextFromRange(stagedRange);
   var translatedData = await util.requestTranslate(
@@ -723,10 +735,9 @@ async function processAutoReader(stagedRange, isTtsSwap) {
   }, autoReaderScrollTime);
   showTooltip(targetText);
 
-  var nextStagedRange = getNextExpandedRange(
-    stagedRange,
-    setting["mouseoverTextType"]
-  );
+  var nextStagedRange =
+    getNextExpandedRange(stagedRange, setting["mouseoverTextType"]) ||
+    getNextBookFusionChapterRange(stagedRange, setting["mouseoverTextType"]);
   preloadNextTranslation(nextStagedRange);
   await callTTS(
     text,
@@ -739,6 +750,14 @@ async function processAutoReader(stagedRange, isTtsSwap) {
   );
 
   processAutoReader(nextStagedRange, isTtsSwap);
+}
+
+function getNextBookFusionChapterRange(currentRange, detectType) {
+  if (!util.isBookFusion() || !currentRange) return null;
+  const iframes = Array.from(document.querySelectorAll('iframe[id^="bf-epub-view-"]'));
+  const idx = iframes.findIndex((f) => f.contentDocument?.contains(currentRange.startContainer));
+  if (idx < 0 || idx >= iframes.length - 1) return null;
+  return getFirstExpandedRangeInDoc(iframes[idx + 1].contentDocument, detectType);
 }
 
 async function preloadNextTranslation(stagedRange) {
@@ -757,7 +776,14 @@ async function preloadNextTranslation(stagedRange) {
 
 function scrollAutoReader(range) {
   var rect = range.getBoundingClientRect();
-  if (util.isBookFusion()) return;
+  if (util.isBookFusion()) {
+    if (!bookFusionActiveIframe) return;
+    var bfRect = bookFusionActiveIframe.getBoundingClientRect();
+    var bfScaleY = bfRect.height / (bookFusionActiveIframe.offsetHeight || 1);
+    var bfScrollTop = window.scrollY + bfRect.top + rect.top * bfScaleY - window.innerHeight / 2;
+    $("body,html").animate({ scrollTop: bfScrollTop }, autoReaderScrollTime);
+    return;
+  }
   const scrollContainer = util.isPDFViewer()
     ? $("#viewerContainer")
     : $("body,html");

--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -563,6 +563,19 @@ function getCenterXY(ele) {
   return { x: centerX, y: centerY };
 }
 
+// get first range in a document (used for next chapter continuation) ===========
+export function getFirstExpandedRangeInDoc(doc, detectType) {
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+    acceptNode: (n) => (n.textContent.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP),
+  });
+  const textNode = walker.nextNode();
+  if (!textNode) return null;
+  const range = doc.createRange();
+  range.setStart(textNode, 0);
+  range.setEnd(textNode, 0);
+  return expandRange(range, detectType) ?? null;
+}
+
 // get next range ===========================
 export function getNextExpandedRange(range, detectType) {
   let nextRange = range;


### PR DESCRIPTION
## Summary

Follow-up fixes for the BookFusion EPUB reader after #323.

- **Auto-reader now scrolls** to keep the current sentence centered while reading, using the iframe's scale transform and position to correctly convert iframe-local coordinates to outer-page scroll position

## Test plan

- [ ] Auto-reader scrolls the page to keep the current sentence centered