### PR TITLE
fix: prevent auto-reader loop at paragraph ending with inline element

### DIFF
--- a/src/event/mouseover.js
+++ b/src/event/mouseover.js
@@ -587,7 +587,26 @@ export function getNextExpandedRange(range, detectType) {
     offsetIncrement += 1;
   }
 
+  // expand("sentence") on inline elements (e.g. <em> containing <img>) can return
+  // a range with the same start as the current range, meaning it expanded backward
+  // into already-read content. Clip to start from where we left off.
+  if (nextRange && rangeHasSameStart(nextRange, range)) {
+    try {
+      const clipped = nextRange.cloneRange();
+      clipped.setStart(range.endContainer, range.endOffset);
+      if (clipped.toString().trim()) return clipped;
+    } catch {}
+    return null;
+  }
+
   return nextRange;
+}
+
+function rangeHasSameStart(nextRange, range) {
+  return (
+    nextRange.startContainer === range.startContainer &&
+    nextRange.startOffset === range.startOffset
+  );
 }
 
 function checkSameRange(range1, range2) {
@@ -598,11 +617,40 @@ function checkSameRange(range1, range2) {
     range1.endOffset === range2.endOffset
   );
 }
+function getFirstTextInNode(node) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return { node, index: 0 };
+  }
+  for (const child of node.childNodes) {
+    const result = getFirstTextInNode(child);
+    if (result) return result;
+  }
+  return null;
+}
+
 function getNextRange(range, offsetIncrement = 1) {
-  const endContainer = range.endContainer;
-  const endOffset = range.endOffset;
+  let endContainer = range.endContainer;
+  let endOffset = range.endOffset;
   const rangeClone = range.cloneRange();
-  const nextNodeAndOffset = getNextNodeAndOffset(endContainer, endOffset + offsetIncrement);
+  let nextNodeAndOffset;
+
+  if (endContainer.nodeType !== Node.TEXT_NODE) {
+    // endOffset is a child-node index; find the first text node starting from that child
+    for (let i = endOffset; i < endContainer.childNodes.length; i++) {
+      nextNodeAndOffset = getFirstTextInNode(endContainer.childNodes[i]);
+      if (nextNodeAndOffset) break;
+    }
+    if (!nextNodeAndOffset) {
+      // no text in remaining children — advance past this element
+      nextNodeAndOffset = getNextNodeAndOffset(
+        getNextSiblingElement(endContainer),
+        0
+      );
+    }
+  } else {
+    nextNodeAndOffset = getNextNodeAndOffset(endContainer, endOffset + offsetIncrement);
+  }
+
   if (!nextNodeAndOffset) return null;
   const { node, index } = nextNodeAndOffset;
   rangeClone.setStart(node, index);


### PR DESCRIPTION
## Summary

When auto-reader reaches a paragraph ending with an inline element (e.g. `<img>`, `<em>` containing `<img>`), it loops back and re-reads earlier sentences.

**Root causes:**

1. `getNextSiblingElement` had no null guard — reaching the top of an iframe's DOM tree caused a crash that stopped auto-reader prematurely.

2. When a paragraph ends with an inline element, `range.expand("sentence")` sets `endContainer` to the parent element with a child-node index as `endOffset`. Rather than converting this offset (which maps badly into `selectNode()`), the fix now directly finds the first text node inside the element at that index, starting at offset 0.

3. For inline elements like `<em>` containing images, `expand("sentence")` expands backward to the same start position as the already-read sentence. The fix detects this (same `startContainer` and `startOffset`) and clips the result to begin where the previous range ended.

## Test plan

- [ ] Auto-reader reads through a paragraph ending with `<img>` without looping
- [ ] Auto-reader reads through a paragraph ending with `<em>` containing inline images without re-reading the preceding sentence
- [ ] Auto-reader on normal paragraphs (no inline elements) is unchanged